### PR TITLE
Added Datastore method getTotalMessageCount

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -79,4 +79,15 @@ public class Datastore {
 
     return messages;
   }
+
+  /**
+   * Returns the total number of messages for all users. 
+   *
+   * @return total number of messages across all users
+   */
+  public int getTotalMessageCount(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    return results.countEntities(FetchOptions.Builder.withLimit(1000));
+  }
 }


### PR DESCRIPTION
Added a method in the Datastore class that allows us to count the total number of messages across all users, up to 1000.