### PR TITLE
Expanded servlet to use Datastore and output JSON

### DIFF
--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,5 +1,8 @@
 package com.google.codeu.servlets;
 
+import com.google.gson.JsonObject;
+import com.google.codeu.data.Datastore;
+
 import java.io.IOException;
 
 import javax.servlet.annotation.WebServlet;
@@ -8,15 +11,29 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Responds with a hard-coded message for testing purposes.
+ * A servlet for handling fetching site statistics.
  */
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet{
+
+  private Datastore datastore;
+
+  @Override
+  public void init() {
+    datastore = new Datastore();
+  }
   
- @Override
- public void doGet(HttpServletRequest request, HttpServletResponse response)
-   throws IOException {
-  
-  response.getOutputStream().println("hello world");
- }
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws IOException {
+    
+    response.setContentType("application/json");
+
+    int messageCount = datastore.getTotalMessageCount();
+
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("messageCount", messageCount);
+    response.getOutputStream().println(jsonObject.toString()); 
+  }
 }
+

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -19,11 +19,19 @@ public class StatsPageServlet extends HttpServlet{
   private Datastore datastore;
 
   @Override
+  /**
+   * Called automatically once when the servlet is first created, 
+   * to create and store a Datastore instance.
+   */
   public void init() {
     datastore = new Datastore();
   }
   
   @Override
+  /**
+   * On page /stats, gets total message count from the datastore and outputs it
+   * as bare-bones JSON format: {"messageCount": messageCount}.
+   */
   public void doGet(HttpServletRequest request, HttpServletResponse response)
     throws IOException {
     


### PR DESCRIPTION
Servlet now outputs actual stats for the total message count instead of the Hello World placeholder. 

Navigate to /stats to see the bare bones output, it should look like `{"messageCount":2}`.