### PR TITLE
Added web page for Stats

### DIFF
--- a/src/main/webapp/js/stats-loader.js
+++ b/src/main/webapp/js/stats-loader.js
@@ -1,0 +1,23 @@
+function fetchStats(){
+  const url = '/stats';
+  fetch(url).then((response) => {
+    return response.json();
+  }).then((stats) => {
+    const statsContainer = document.getElementById('stats-container');
+    statsContainer.innerHTML = '';
+
+    const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+    statsContainer.appendChild(messageCountElement);
+  });
+}
+
+function buildStatElement(statString){
+ const statElement = document.createElement('p');
+ statElement.appendChild(document.createTextNode(statString));
+ return statElement;
+}
+
+// Fetch data and populate the UI of the page.
+function buildUI(){
+ fetchStats();
+}

--- a/src/main/webapp/js/stats-loader.js
+++ b/src/main/webapp/js/stats-loader.js
@@ -1,3 +1,5 @@
+// Fetches the JSON object containing stats and populates the 
+// stats-container div in stats.html with its contents.
 function fetchStats(){
   const url = '/stats';
   fetch(url).then((response) => {

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Stats</title>
+  <link rel="stylesheet" href="/css/main.css">
+  
+  <script>
+    // Fetch stats and display them in the page.
+    function fetchStats(){
+      const url = '/stats';
+      fetch(url).then((response) => {
+        return response.json();
+      }).then((stats) => {
+        const statsContainer = document.getElementById('stats-container');
+        statsContainer.innerHTML = '';
+
+        const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+        statsContainer.appendChild(messageCountElement);
+      });
+    }
+
+    function buildStatElement(statString){
+     const statElement = document.createElement('p');
+     statElement.appendChild(document.createTextNode(statString));
+     return statElement;
+    }
+
+    // Fetch data and populate the UI of the page.
+    function buildUI(){
+     fetchStats();
+    }
+  </script>
+</head>
+<body onload="buildUI()">
+<div id="content">
+  <h1>Site Statistics</h1>
+  <hr/>
+  <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -3,33 +3,7 @@
 <head>
   <title>Stats</title>
   <link rel="stylesheet" href="/css/main.css">
-  
-  <script>
-    // Fetch stats and display them in the page.
-    function fetchStats(){
-      const url = '/stats';
-      fetch(url).then((response) => {
-        return response.json();
-      }).then((stats) => {
-        const statsContainer = document.getElementById('stats-container');
-        statsContainer.innerHTML = '';
-
-        const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
-        statsContainer.appendChild(messageCountElement);
-      });
-    }
-
-    function buildStatElement(statString){
-     const statElement = document.createElement('p');
-     statElement.appendChild(document.createTextNode(statString));
-     return statElement;
-    }
-
-    // Fetch data and populate the UI of the page.
-    function buildUI(){
-     fetchStats();
-    }
-  </script>
+  <script src = "js/stats-loader.js"> </script>
 </head>
 <body onload="buildUI()">
 <div id="content">


### PR DESCRIPTION
Navigating to /stats.html now displays a basic stats page, with total message count.

Inline JavaScript originally in `stats.html` moved to separate `stats-loader.js`