### PR TITLE
Implement quick fixes for bugs with loading messages and posting replies

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -191,6 +191,7 @@ public class Datastore {
     Query query = new Query("Message");
     query.setFilter(new Query.FilterPredicate("recipient", FilterOperator.EQUAL, recipient));
     query.setFilter(new Query.FilterPredicate("imageURL", FilterOperator.NOT_EQUAL, null));
+    query.addSort("imageURL");
     query.addSort("timestamp", SortDirection.DESCENDING);
 
     PreparedQuery results = datastore.prepare(query);


### PR DESCRIPTION
This implements two quick fixes:

1. I added the `imageURL` to the sort for the Datastore query that fetches messages with images. Apparently this is a Datastore restriction.

2. I moved all of the Blobstore logic into a try/catch block. When a reply is posted, the code still throws an exception, but the code basically ignores it. This is a hack, but it'll get us unblocked.