### PR TITLE
Commissions toggle labeled and moved below PFP

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/user-page.jsp
+++ b/src/main/webapp/WEB-INF/jsp/user-page.jsp
@@ -21,14 +21,15 @@
 
       <div id="sidebar">
 
+        <p id= "profilepic" src=""></p>
+
         <div id="commissions-toggle" class="hidden">
           <label class="switch">
             <input type="checkbox" id="commissions-checkbox" onclick="setCommissions()">
             <span class="slider" id="commissions-slider"></span>
+            <p>Taking Commissions?</p>
           </label>
         </div>
-
-        <p id= "profilepic" src=""></p>
 
         <div id="name">
           <a href="user-page.jsp" id="page-title">User Page</a>


### PR DESCRIPTION
The commissions toggle has been moved below the user's profile picture and now displays "Taking Commissions?" to the user so they have a better idea what it does.