### PR TITLE
Linkify usernames to their user pages.

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -86,6 +86,19 @@ hr{
   padding: 5px;
 }
 
+/* Username links are the same color as nav links. */
+.message-header a {
+  color: #2a7b88;
+  text-decoration: none;
+  /* When you hover, the color slowly changes. */
+  transition: color 1s;
+}
+
+/* Inverse the username link upon hover. */
+.message-header a:hover {
+  color: #d58477;
+}
+
 /* Give the message body a margin so the text
    isn't too close to the border. */
 .message-body {

--- a/src/main/webapp/js/feed-loader.js
+++ b/src/main/webapp/js/feed-loader.js
@@ -48,10 +48,16 @@ function fetchReplies(message) {
 function buildMessageDiv(message, margin) {
   const headerDiv = document.createElement('div');
   headerDiv.classList.add('message-header');
-  headerDiv.appendChild(document.createTextNode(
-      message.user + ' - ' +
-      new Date(message.timestamp) +
-      ' [' + message.sentimentScore + ']'));
+
+  const userPageLink = document.createElement('a');
+  userPageLink.appendChild(document.createTextNode(message.user));
+  userPageLink.setAttribute('href', '/users/' + message.user);
+
+  headerDiv.appendChild(userPageLink);
+  headerDiv.appendChild(document.createTextNode(' - '));
+  headerDiv.appendChild(
+      document.createTextNode(new Date(message.timestamp).toLocaleString('en-US')));
+  headerDiv.appendChild(document.createTextNode(' - [Sentiment: ' + message.sentimentScore + ']'));
 
   const bodyDiv = document.createElement('div');
   if(message.imageURL){

--- a/src/main/webapp/js/user-page-loader.js
+++ b/src/main/webapp/js/user-page-loader.js
@@ -188,10 +188,16 @@ function fetchAboutMe() {
 function buildMessageDiv(message, margin) {
   const headerDiv = document.createElement('div');
   headerDiv.classList.add('message-header');
-  headerDiv.appendChild(document.createTextNode(
-      message.user + ' - ' +
-      new Date(message.timestamp) +
-      ' [' + message.sentimentScore + ']'));
+
+  const userPageLink = document.createElement('a');
+  userPageLink.appendChild(document.createTextNode(message.user));
+  userPageLink.setAttribute('href', '/users/' + message.user);
+
+  headerDiv.appendChild(userPageLink);
+  headerDiv.appendChild(document.createTextNode(' - '));
+  headerDiv.appendChild(
+      document.createTextNode(new Date(message.timestamp).toLocaleString('en-US')));
+  headerDiv.appendChild(document.createTextNode(' - [Sentiment: ' + message.sentimentScore + ']'));
 
   const bodyDiv = document.createElement('div');
   if(message.imageURL){


### PR DESCRIPTION
I linkified the username in the message heading so it's easier to get to the user pages. I also formatted the date.

While I'm here I made the usernames the same color as the nav links. When you mouse over the username, its color slowly changes to orange (the inverse of the original color).

It looks roughly like this: https://i.imgur.com/jND70wo.png

From here we could do something like chop off the `@whatever` part of the email just to clean up the display. We could also think harder about formatting the date correctly in various locales. But for now this at least provides a quick link to user pages, which makes it easier for people to see the functionality there.