### PR TITLE
Modification to indexing for the Datastore

### DIFF
--- a/src/main/webapp/WEB-INF/index.yaml
+++ b/src/main/webapp/WEB-INF/index.yaml
@@ -18,5 +18,6 @@ indexes:
   - name: user
   - name: recipient
   - name: sentimentScore
+  - name: imageURL
   - name: timestamp
     direction: desc


### PR DESCRIPTION
This allows us to index on `imageURL` without the Datastore complaining or silently failing. This is intended to fix the problem that some users have reported where occasionally the gallery query to the datastore fails.